### PR TITLE
fail on GitHub auth failure

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -31,6 +31,7 @@ mkdir $tmp/$TODAY
 cd $tmp/$TODAY
 
 get_repos() (
+  set -euo pipefail
   url=https://api.github.com/user/repos
   auth="Authorization: Bearer $GITHUB_TOKEN"
   tmp_dir=$(mktemp -d)


### PR DESCRIPTION
Without this we silently get an empty list of repositories and the script immediately thinks it's done, happy to return an empty tarball.